### PR TITLE
Send sftp packets in parallel

### DIFF
--- a/client.go
+++ b/client.go
@@ -13,6 +13,8 @@ import (
 	"code.google.com/p/go.crypto/ssh"
 )
 
+const maxOutstandingPackets = 128 // default from openssh sftp client: 64
+
 // New creates a new SFTP client on conn.
 func NewClient(conn *ssh.Client) (*Client, error) {
 	s, err := conn.NewSession()
@@ -39,13 +41,25 @@ func NewClient(conn *ssh.Client) (*Client, error) {
 // the system's ssh client program (e.g. via exec.Command).
 func NewClientPipe(rd io.Reader, wr io.WriteCloser) (*Client, error) {
 	sftp := &Client{
-		w: wr,
-		r: rd,
+		w:         wr,
+		r:         rd,
+		done:      make(chan struct{}),
+		pktsOutCh: make(chan idCh, maxOutstandingPackets),
 	}
 	if err := sftp.sendInit(); err != nil {
 		return nil, err
 	}
-	return sftp, sftp.recvVersion()
+
+	if err := sftp.recvVersion(); err != nil {
+		return nil, err
+	}
+
+	// start packet receiving goroutine
+	ch := make(chan pkt, maxOutstandingPackets)
+	go sftp.demux(ch)
+	go sftp.mux(ch)
+
+	return sftp, nil
 }
 
 // Client represents an SFTP session on a *ssh.ClientConn SSH connection.
@@ -56,12 +70,35 @@ func NewClientPipe(rd io.Reader, wr io.WriteCloser) (*Client, error) {
 type Client struct {
 	w      io.WriteCloser
 	r      io.Reader
-	mu     sync.Mutex // locks mu and seralises commands to the server
+	idMu   sync.Mutex // locks mu and seralises access to nextid
 	nextid uint32
+
+	sendMu    sync.Mutex // guarantees atomic operation for sending packets
+	pktsOutCh chan idCh
+	done      chan struct{}
+	closeOnce sync.Once
+}
+
+// pkt holds a packet to be sent or received from the server, including a potential send/receive error.
+type pkt struct {
+	typ  uint8
+	data []uint8
+	err  error
+}
+
+// idCh tracks a packet that is to be sent. The response packet is sent to the channel ch.
+type idCh struct {
+	id uint32
+	ch chan<- pkt
+	p  encoding.BinaryMarshaler
 }
 
 // Close closes the SFTP session.
-func (c *Client) Close() error { return c.w.Close() }
+func (c *Client) Close() error {
+	// send exit requests to goroutines
+	c.closeOnce.Do(func() { close(c.done) })
+	return c.w.Close()
+}
 
 // Create creates the named file mode 0666 (before umask), truncating it if
 // it already exists. If successful, methods on the returned File can be
@@ -72,15 +109,84 @@ func (c *Client) Create(path string) (*File, error) {
 
 const sftpProtocolVersion = 3 // http://tools.ietf.org/html/draft-ietf-secsh-filexfer-02
 
+// demux receives packets from the server and sends them out to the
+// appropiate channel. When an error is received, it is sent to the channel and
+// no more packets are received.
+func (c *Client) demux(outch chan<- pkt) {
+	for {
+		// receive packet
+		typ, data, err := recvPacket(c.r)
+		if err == io.EOF {
+			return
+		}
+
+		p := pkt{typ, data, err}
+
+		select {
+		case outch <- p:
+		case <-c.done:
+			return
+		}
+
+		// stop receiving packets on error
+		if err != nil {
+			return
+		}
+	}
+}
+
+// mux processes packets from the channel and sends them out to the
+// appropiate channel.
+func (c *Client) mux(inch <-chan pkt) {
+	chans := make(map[uint32]chan<- pkt)
+	for {
+		select {
+		case <-c.done:
+			return
+
+		case idch := <-c.pktsOutCh:
+			err := sendPacket(c.w, idch.p)
+			if err != nil {
+				idch.ch <- pkt{err: err}
+			}
+			chans[idch.id] = idch.ch
+
+		case p := <-inch:
+			id, _ := unmarshalUint32(p.data)
+
+			// send packet to appropiate channel, otherwise silently drop it
+			if ch, ok := chans[id]; ok {
+				// send packet to process
+				ch <- pkt{p.typ, p.data, p.err}
+
+				// remove chan from map
+				delete(chans, id)
+			}
+		}
+	}
+}
+
+// sendPackets sends packet p, the response is delivered to channel ch.
+func (c *Client) sendPacket(p encoding.BinaryMarshaler, id uint32, ch chan<- pkt) error {
+	c.sendMu.Lock()
+	defer c.sendMu.Unlock()
+
+	c.pktsOutCh <- idCh{ch: ch, id: id, p: p}
+
+	return nil
+}
+
 func (c *Client) sendInit() error {
 	return sendPacket(c.w, sshFxInitPacket{
 		Version: sftpProtocolVersion, // http://tools.ietf.org/html/draft-ietf-secsh-filexfer-02
 	})
 }
 
-// returns the current value of c.nextid and increments it
-// callers is expected to hold c.mu
+// returns the current value of c.nextid and increments. Can be called by
+// multiple goroutines in parallel.
 func (c *Client) nextId() uint32 {
+	c.idMu.Lock()
+	defer c.idMu.Unlock()
 	v := c.nextid
 	c.nextid++
 	return v
@@ -117,23 +223,22 @@ func (c *Client) ReadDir(p string) ([]os.FileInfo, error) {
 	}
 	defer c.close(handle) // this has to defer earlier than the lock below
 	var attrs []os.FileInfo
-	c.mu.Lock()
-	defer c.mu.Unlock()
 	var done = false
+	// TODO(fd0) send sshFxpReaddirPackets in parallel
 	for !done {
 		id := c.nextId()
-		typ, data, err1 := c.sendRequest(sshFxpReaddirPacket{
+		pkt, err1 := c.sendRequest(sshFxpReaddirPacket{
 			Id:     id,
 			Handle: handle,
-		})
+		}, id)
 		if err1 != nil {
 			err = err1
 			done = true
 			break
 		}
-		switch typ {
+		switch pkt.typ {
 		case ssh_FXP_NAME:
-			sid, data := unmarshalUint32(data)
+			sid, data := unmarshalUint32(pkt.data)
 			if sid != id {
 				return nil, &unexpectedIdErr{id, sid}
 			}
@@ -151,10 +256,10 @@ func (c *Client) ReadDir(p string) ([]os.FileInfo, error) {
 			}
 		case ssh_FXP_STATUS:
 			// TODO(dfc) scope warning!
-			err = eofOrErr(unmarshalStatus(id, data))
+			err = eofOrErr(unmarshalStatus(id, pkt.data))
 			done = true
 		default:
-			return nil, unimplementedPacketErr(typ)
+			return nil, unimplementedPacketErr(pkt.typ)
 		}
 	}
 	if err == io.EOF {
@@ -162,73 +267,68 @@ func (c *Client) ReadDir(p string) ([]os.FileInfo, error) {
 	}
 	return attrs, err
 }
+
 func (c *Client) opendir(path string) (string, error) {
-	c.mu.Lock()
-	defer c.mu.Unlock()
 	id := c.nextId()
-	typ, data, err := c.sendRequest(sshFxpOpendirPacket{
+	pkt, err := c.sendRequest(sshFxpOpendirPacket{
 		Id:   id,
 		Path: path,
-	})
+	}, id)
 	if err != nil {
 		return "", err
 	}
-	switch typ {
+	switch pkt.typ {
 	case ssh_FXP_HANDLE:
-		sid, data := unmarshalUint32(data)
+		sid, data := unmarshalUint32(pkt.data)
 		if sid != id {
 			return "", &unexpectedIdErr{id, sid}
 		}
 		handle, _ := unmarshalString(data)
 		return handle, nil
 	case ssh_FXP_STATUS:
-		return "", unmarshalStatus(id, data)
+		return "", unmarshalStatus(id, pkt.data)
 	default:
-		return "", unimplementedPacketErr(typ)
+		return "", unimplementedPacketErr(pkt.typ)
 	}
 }
 
 func (c *Client) Lstat(p string) (os.FileInfo, error) {
-	c.mu.Lock()
-	defer c.mu.Unlock()
 	id := c.nextId()
-	typ, data, err := c.sendRequest(sshFxpLstatPacket{
+	pkt, err := c.sendRequest(sshFxpLstatPacket{
 		Id:   id,
 		Path: p,
-	})
+	}, id)
 	if err != nil {
 		return nil, err
 	}
-	switch typ {
+	switch pkt.typ {
 	case ssh_FXP_ATTRS:
-		sid, data := unmarshalUint32(data)
+		sid, data := unmarshalUint32(pkt.data)
 		if sid != id {
 			return nil, &unexpectedIdErr{id, sid}
 		}
 		attr, _ := unmarshalAttrs(data)
 		return fileInfoFromStat(attr, path.Base(p)), nil
 	case ssh_FXP_STATUS:
-		return nil, unmarshalStatus(id, data)
+		return nil, unmarshalStatus(id, pkt.data)
 	default:
-		return nil, unimplementedPacketErr(typ)
+		return nil, unimplementedPacketErr(pkt.typ)
 	}
 }
 
 // ReadLink reads the target of a symbolic link.
 func (c *Client) ReadLink(p string) (string, error) {
-	c.mu.Lock()
-	defer c.mu.Unlock()
 	id := c.nextId()
-	typ, data, err := c.sendRequest(sshFxpReadlinkPacket{
+	pkt, err := c.sendRequest(sshFxpReadlinkPacket{
 		Id:   id,
 		Path: p,
-	})
+	}, id)
 	if err != nil {
 		return "", err
 	}
-	switch typ {
+	switch pkt.typ {
 	case ssh_FXP_NAME:
-		sid, data := unmarshalUint32(data)
+		sid, data := unmarshalUint32(pkt.data)
 		if sid != id {
 			return "", &unexpectedIdErr{id, sid}
 		}
@@ -239,31 +339,29 @@ func (c *Client) ReadLink(p string) (string, error) {
 		filename, _ := unmarshalString(data) // ignore dummy attributes
 		return filename, nil
 	case ssh_FXP_STATUS:
-		return "", unmarshalStatus(id, data)
+		return "", unmarshalStatus(id, pkt.data)
 	default:
-		return "", unimplementedPacketErr(typ)
+		return "", unimplementedPacketErr(pkt.typ)
 	}
 }
 
 // setstat is a convience wrapper to allow for changing of various parts of the file descriptor.
 func (c *Client) setstat(path string, flags uint32, attrs interface{}) error {
-	c.mu.Lock()
-	defer c.mu.Unlock()
 	id := c.nextId()
-	typ, data, err := c.sendRequest(sshFxpSetstatPacket{
+	pkt, err := c.sendRequest(sshFxpSetstatPacket{
 		Id:    id,
 		Path:  path,
 		Flags: flags,
 		Attrs: attrs,
-	})
+	}, id)
 	if err != nil {
 		return err
 	}
-	switch typ {
+	switch pkt.typ {
 	case ssh_FXP_STATUS:
-		return okOrErr(unmarshalStatus(id, data))
+		return okOrErr(unmarshalStatus(id, pkt.data))
 	default:
-		return unimplementedPacketErr(typ)
+		return unimplementedPacketErr(pkt.typ)
 	}
 }
 
@@ -315,108 +413,89 @@ func (c *Client) OpenFile(path string, f int) (*File, error) {
 }
 
 func (c *Client) open(path string, pflags uint32) (*File, error) {
-	c.mu.Lock()
-	defer c.mu.Unlock()
 	id := c.nextId()
-	typ, data, err := c.sendRequest(sshFxpOpenPacket{
+	pkt, err := c.sendRequest(sshFxpOpenPacket{
 		Id:     id,
 		Path:   path,
 		Pflags: pflags,
-	})
+	}, id)
 	if err != nil {
 		return nil, err
 	}
-	switch typ {
+	switch pkt.typ {
 	case ssh_FXP_HANDLE:
-		sid, data := unmarshalUint32(data)
+		sid, data := unmarshalUint32(pkt.data)
 		if sid != id {
 			return nil, &unexpectedIdErr{id, sid}
 		}
 		handle, _ := unmarshalString(data)
 		return &File{c: c, path: path, handle: handle}, nil
 	case ssh_FXP_STATUS:
-		return nil, unmarshalStatus(id, data)
+		return nil, unmarshalStatus(id, pkt.data)
 	default:
-		return nil, unimplementedPacketErr(typ)
+		return nil, unimplementedPacketErr(pkt.typ)
 	}
 }
 
-// readAt reads len(buf) bytes from the remote file indicated by handle starting
-// from offset.
-func (c *Client) readAt(handle string, offset uint64, buf []byte) (uint32, error) {
-	c.mu.Lock()
-	defer c.mu.Unlock()
+// readAt sends a packet to read len(buf) bytes from the remote file indicated
+// by handle starting from offset, the response packet is sent to ch. Returned
+// is the packet id.
+func (c *Client) readAt(handle string, ch chan<- pkt, offset uint64, buf []byte) (uint32, error) {
 	id := c.nextId()
-	typ, data, err := c.sendRequest(sshFxpReadPacket{
+	err := c.sendPacket(sshFxpReadPacket{
 		Id:     id,
 		Handle: handle,
 		Offset: offset,
 		Len:    uint32(len(buf)),
-	})
+	}, id, ch)
 	if err != nil {
 		return 0, err
 	}
-	switch typ {
-	case ssh_FXP_DATA:
-		sid, data := unmarshalUint32(data)
-		if sid != id {
-			return 0, &unexpectedIdErr{id, sid}
-		}
-		l, data := unmarshalUint32(data)
-		n := copy(buf, data[:l])
-		return uint32(n), nil
-	case ssh_FXP_STATUS:
-		return 0, eofOrErr(unmarshalStatus(id, data))
-	default:
-		return 0, unimplementedPacketErr(typ)
-	}
+
+	return id, nil
 }
 
 // close closes a handle handle previously returned in the response
 // to SSH_FXP_OPEN or SSH_FXP_OPENDIR. The handle becomes invalid
 // immediately after this request has been sent.
 func (c *Client) close(handle string) error {
-	c.mu.Lock()
-	defer c.mu.Unlock()
 	id := c.nextId()
-	typ, data, err := c.sendRequest(sshFxpClosePacket{
+	pkt, err := c.sendRequest(sshFxpClosePacket{
 		Id:     id,
 		Handle: handle,
-	})
+	}, id)
 	if err != nil {
 		return err
 	}
-	switch typ {
+	switch pkt.typ {
 	case ssh_FXP_STATUS:
-		return okOrErr(unmarshalStatus(id, data))
+		return okOrErr(unmarshalStatus(id, pkt.data))
 	default:
-		return unimplementedPacketErr(typ)
+		return unimplementedPacketErr(pkt.typ)
 	}
 }
 
 func (c *Client) fstat(handle string) (*FileStat, error) {
-	c.mu.Lock()
-	defer c.mu.Unlock()
 	id := c.nextId()
-	typ, data, err := c.sendRequest(sshFxpFstatPacket{
+	pkt, err := c.sendRequest(sshFxpFstatPacket{
 		Id:     id,
 		Handle: handle,
-	})
+	}, id)
 	if err != nil {
 		return nil, err
 	}
-	switch typ {
+	switch pkt.typ {
 	case ssh_FXP_ATTRS:
-		sid, data := unmarshalUint32(data)
+		sid, data := unmarshalUint32(pkt.data)
 		if sid != id {
 			return nil, &unexpectedIdErr{id, sid}
 		}
 		attr, _ := unmarshalAttrs(data)
 		return attr, nil
 	case ssh_FXP_STATUS:
-		return nil, unmarshalStatus(id, data)
+		return nil, unmarshalStatus(id, pkt.data)
 	default:
-		return nil, unimplementedPacketErr(typ)
+		return nil, unimplementedPacketErr(pkt.typ)
 	}
 }
 
@@ -437,117 +516,105 @@ func (c *Client) Remove(path string) error {
 }
 
 func (c *Client) removeFile(path string) error {
-	c.mu.Lock()
-	defer c.mu.Unlock()
 	id := c.nextId()
-	typ, data, err := c.sendRequest(sshFxpRemovePacket{
+	pkt, err := c.sendRequest(sshFxpRemovePacket{
 		Id:       id,
 		Filename: path,
-	})
+	}, id)
 	if err != nil {
 		return err
 	}
-	switch typ {
+	switch pkt.typ {
 	case ssh_FXP_STATUS:
-		return okOrErr(unmarshalStatus(id, data))
+		return okOrErr(unmarshalStatus(id, pkt.data))
 	default:
-		return unimplementedPacketErr(typ)
+		return unimplementedPacketErr(pkt.typ)
 	}
 }
 
 func (c *Client) removeDirectory(path string) error {
-	c.mu.Lock()
-	defer c.mu.Unlock()
 	id := c.nextId()
-	typ, data, err := c.sendRequest(sshFxpRmdirPacket{
+	pkt, err := c.sendRequest(sshFxpRmdirPacket{
 		Id:   id,
 		Path: path,
-	})
+	}, id)
 	if err != nil {
 		return err
 	}
-	switch typ {
+	switch pkt.typ {
 	case ssh_FXP_STATUS:
-		return okOrErr(unmarshalStatus(id, data))
+		return okOrErr(unmarshalStatus(id, pkt.data))
 	default:
-		return unimplementedPacketErr(typ)
+		return unimplementedPacketErr(pkt.typ)
 	}
 }
 
 // Rename renames a file.
 func (c *Client) Rename(oldname, newname string) error {
-	c.mu.Lock()
-	defer c.mu.Unlock()
 	id := c.nextId()
-	typ, data, err := c.sendRequest(sshFxpRenamePacket{
+	pkt, err := c.sendRequest(sshFxpRenamePacket{
 		Id:      id,
 		Oldpath: oldname,
 		Newpath: newname,
-	})
+	}, id)
 	if err != nil {
 		return err
 	}
-	switch typ {
+	switch pkt.typ {
 	case ssh_FXP_STATUS:
-		return okOrErr(unmarshalStatus(id, data))
+		return okOrErr(unmarshalStatus(id, pkt.data))
 	default:
-		return unimplementedPacketErr(typ)
+		return unimplementedPacketErr(pkt.typ)
 	}
 }
 
-func (c *Client) sendRequest(p encoding.BinaryMarshaler) (byte, []byte, error) {
-	if err := sendPacket(c.w, p); err != nil {
-		return 0, nil, err
+// sendRequest sends a packet and blocks until the answer has arrived.
+func (c *Client) sendRequest(p encoding.BinaryMarshaler, id uint32) (*pkt, error) {
+	ch := make(chan pkt, 1)
+	err := c.sendPacket(p, id, ch)
+	if err != nil {
+		return nil, err
 	}
-	return recvPacket(c.r)
+
+	// wait for response
+	pkt := <-ch
+
+	return &pkt, nil
 }
 
-// writeAt writes len(buf) bytes from the remote file indicated by handle starting
-// from offset.
-func (c *Client) writeAt(handle string, offset uint64, buf []byte) (uint32, error) {
-	c.mu.Lock()
-	defer c.mu.Unlock()
+// writeAt writes len(buf) bytes to the remote file indicated by handle starting
+// from offset. The response packets are sent to channel ch, returned is the packet
+// id or the sending error, if any.
+func (c *Client) writeAt(handle string, ch chan<- pkt, offset uint64, buf []byte) (uint32, error) {
 	id := c.nextId()
-	typ, data, err := c.sendRequest(sshFxpWritePacket{
+	err := c.sendPacket(sshFxpWritePacket{
 		Id:     id,
 		Handle: handle,
 		Offset: offset,
 		Length: uint32(len(buf)),
 		Data:   buf,
-	})
-	if err != nil {
-		return 0, err
-	}
-	switch typ {
-	case ssh_FXP_STATUS:
-		if err := okOrErr(unmarshalStatus(id, data)); err != nil {
-			return 0, nil
-		}
-		return uint32(len(buf)), nil
-	default:
-		return 0, unimplementedPacketErr(typ)
-	}
+	}, id, ch)
+
+	return id, err
 }
 
 // Creates the specified directory. An error will be returned if a file or
 // directory with the specified path already exists, or if the directory's
 // parent folder does not exist (the method cannot create complete paths).
 func (c *Client) Mkdir(path string) error {
-	c.mu.Lock()
-	defer c.mu.Unlock()
 	id := c.nextId()
-	typ, data, err := c.sendRequest(sshFxpMkdirPacket{
+	pkt, err := c.sendRequest(sshFxpMkdirPacket{
 		Id:   id,
 		Path: path,
-	})
+	}, id)
 	if err != nil {
 		return err
 	}
-	switch typ {
+	switch pkt.typ {
 	case ssh_FXP_STATUS:
-		return okOrErr(unmarshalStatus(id, data))
+		return okOrErr(unmarshalStatus(id, pkt.data))
 	default:
-		return unimplementedPacketErr(typ)
+		return unimplementedPacketErr(pkt.typ)
 	}
 }
 
@@ -569,17 +636,107 @@ func (f *File) Close() error {
 // bytes read and an error, if any. EOF is signaled by a zero count with
 // err set to io.EOF.
 func (f *File) Read(b []byte) (int, error) {
-	var read int
-	for len(b) > 0 {
-		n, err := f.c.readAt(f.handle, f.offset, b[:min(len(b), maxWritePacket)])
-		f.offset += uint64(n)
-		read += int(n)
-		if err != nil {
-			return read, err
-		}
-		b = b[n:]
+	var firstErr error
+	inFlight := 0
+	read := 0
+	offset := f.offset
+	maxInFlight := 2 // for a slow start
+
+	// only allocate channels with buffer size maxOutstandingPackets if buffer is sufficiently large
+	maxPkts := min(len(b)/maxWritePacket+1, maxOutstandingPackets)
+
+	// create channel for the response packets
+	ch := make(chan pkt, maxPkts)
+
+	type ack struct {
+		id   uint32
+		size int
+		seen bool
+		data []uint8
 	}
-	return read, nil
+	acks := make([]ack, 0, maxPkts)
+
+	for inFlight > 0 || len(b) > 0 {
+		for inFlight < maxInFlight && len(b) > 0 && firstErr == nil {
+			// send packet
+			l := min(len(b), maxWritePacket)
+			id, err := f.c.readAt(f.handle, ch, offset, b[:l])
+
+			// if an error occurred while sending, set firstErr and exit the sending loop
+			if err != nil {
+				firstErr = err
+				break
+			}
+
+			offset += uint64(l)
+
+			acks = append(acks, ack{id: id, size: l, data: b[:l]})
+			b = b[l:]
+			inFlight++
+		}
+
+		// if there are no packets in flight any more (e.g. because firstErr is set), exit the loop
+		if inFlight == 0 {
+			break
+		}
+
+		// otherwise try to process a response packet
+	receiveLoop:
+		select {
+		case pkt := <-ch:
+			inFlight--
+
+			// extract id
+			id, data := unmarshalUint32(pkt.data)
+
+			// check for correct status packet
+			if pkt.typ == ssh_FXP_STATUS {
+				firstErr = eofOrErr(unmarshalStatus(id, pkt.data))
+			} else if pkt.typ != ssh_FXP_DATA {
+				firstErr = unimplementedPacketErr(pkt.typ)
+			}
+
+			if firstErr != nil {
+				break receiveLoop
+			}
+
+			// here pkt.typ == ssh_FXP_DATA and firstErr == nil holds
+
+			if maxInFlight < maxOutstandingPackets {
+				maxInFlight = min(maxInFlight*2, maxOutstandingPackets)
+			}
+
+			// search id
+			found := false
+			idx := 0
+			for i := 0; i < len(acks); i++ {
+				if acks[i].id == id {
+					idx = i
+					found = true
+				}
+			}
+
+			if found {
+				acks[idx].seen = true
+				l, data := unmarshalUint32(data)
+				copy(acks[idx].data, data[:l])
+				acks[idx].size = int(l)
+
+				for len(acks) > 0 && acks[0].seen {
+					f.offset += uint64(acks[0].size)
+					read += acks[0].size
+
+					if len(acks) > 1 {
+						acks = acks[1:]
+					} else {
+						acks = []ack{}
+					}
+				}
+			}
+		}
+
+	}
+	return read, firstErr
 }
 
 // Stat returns the FileInfo structure describing file. If there is an
@@ -599,17 +756,104 @@ const maxWritePacket = 1 << 15
 // written and an error, if any. Write returns a non-nil error when n !=
 // len(b).
 func (f *File) Write(b []byte) (int, error) {
-	var written int
-	for len(b) > 0 {
-		n, err := f.c.writeAt(f.handle, f.offset, b[:min(len(b), maxWritePacket)])
-		f.offset += uint64(n)
-		written += int(n)
-		if err != nil {
-			return written, err
-		}
-		b = b[n:]
+	var (
+		firstErr error
+		inFlight int
+		written  int
+	)
+	offset := f.offset
+
+	// only allocate channels with buffer size maxOutstandingPackets if buffer is sufficiently large
+	maxPkts := min(len(b)/maxWritePacket+1, maxOutstandingPackets)
+
+	// create channel for the response packets
+	ch := make(chan pkt, maxPkts)
+
+	type ack struct {
+		id   uint32
+		size int
+		seen bool
 	}
-	return written, nil
+	acks := make([]ack, 0, maxPkts)
+
+	for inFlight > 0 || len(b) > 0 {
+		for inFlight < maxPkts && len(b) > 0 && firstErr == nil {
+			// send packet
+			l := min(len(b), maxWritePacket)
+			id, err := f.c.writeAt(f.handle, ch, offset, b[:l])
+
+			// if an error occurred while sending, set firstErr and exit the sending loop
+			if err != nil {
+				firstErr = err
+				break
+			}
+
+			offset += uint64(l)
+
+			acks = append(acks, ack{id: id, size: l})
+			b = b[l:]
+			inFlight++
+		}
+
+		// if there are no packets in flight any more (e.g. because firstErr is set), exit the loop
+		if inFlight == 0 {
+			break
+		}
+
+		// otherwise try to process a response packet
+	receiveLoop:
+		select {
+		case pkt := <-ch:
+			inFlight--
+
+			// extract id
+			id, _ := unmarshalUint32(pkt.data)
+
+			// check for correct status packet
+			switch pkt.typ {
+			case ssh_FXP_STATUS:
+				if err := okOrErr(unmarshalStatus(id, pkt.data)); err != nil {
+					if firstErr == nil {
+						firstErr = err
+					}
+				}
+			default:
+				if firstErr == nil {
+					firstErr = unimplementedPacketErr(pkt.typ)
+				}
+			}
+
+			if firstErr != nil {
+				break receiveLoop
+			}
+
+			// search id
+			found := false
+			idx := 0
+			for i := 0; i < len(acks); i++ {
+				if acks[i].id == id {
+					idx = i
+					found = true
+				}
+			}
+
+			if found {
+				acks[idx].seen = true
+
+				for len(acks) > 0 && acks[0].seen {
+					f.offset += uint64(acks[0].size)
+					written += acks[0].size
+
+					if len(acks) > 1 {
+						acks = acks[1:]
+					} else {
+						acks = []ack{}
+					}
+				}
+			}
+		}
+	}
+	return written, firstErr
 }
 
 // Seek implements io.Seeker by setting the client offset for the next Read or

--- a/client_integration_test.go
+++ b/client_integration_test.go
@@ -58,14 +58,6 @@ func testClient(t testing.TB, readonly bool) (*Client, *exec.Cmd) {
 		t.Fatal(err)
 	}
 
-	if err := sftp.sendInit(); err != nil {
-		defer cmd.Wait()
-		t.Fatal(err)
-	}
-	if err := sftp.recvVersion(); err != nil {
-		defer cmd.Wait()
-		t.Fatal(err)
-	}
 	return sftp, cmd
 }
 
@@ -73,6 +65,11 @@ func TestNewClient(t *testing.T) {
 	sftp, cmd := testClient(t, READONLY)
 	defer cmd.Wait()
 
+	if err := sftp.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	// call Close() a second time, this should not panic
 	if err := sftp.Close(); err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
Benchmarks before:

    BenchmarkRead1k           10     142398598 ns/op      73.64 MB/s
    BenchmarkRead16k          50      32758323 ns/op     320.10 MB/s
    BenchmarkRead32k         100      42391983 ns/op     247.36 MB/s
    BenchmarkRead128k         50      42014906 ns/op     249.58 MB/s
    BenchmarkRead512k         50      32767844 ns/op     320.01 MB/s
    BenchmarkRead1MiB         50      38830615 ns/op     270.04 MB/s
    BenchmarkRead4MiB         50      33023037 ns/op     317.53 MB/s
    BenchmarkWrite1k          10     140492382 ns/op      74.64 MB/s
    BenchmarkWrite16k         50      37735998 ns/op     277.87 MB/s
    BenchmarkWrite32k         50      34301633 ns/op     305.70 MB/s
    BenchmarkWrite128k        50      29061948 ns/op     360.81 MB/s
    BenchmarkWrite512k        50      36087549 ns/op     290.57 MB/s
    BenchmarkWrite1MiB        50      39458367 ns/op     265.75 MB/s
    BenchmarkWrite4MiB        50      32230107 ns/op     325.34 MB/s
    BenchmarkMarshalInit     5000000           651 ns/op
    BenchmarkMarshalOpen     5000000           577 ns/op
    BenchmarkMarshalWriteWorstCase     50000         46544 ns/op
    BenchmarkMarshalWrite1k   500000          2823 ns/op
    ok      github.com/pkg/sftp 39.618s

after:

    BenchmarkRead1k        1        1069701026 ns/op           9.80 MB/s
    BenchmarkRead16k              20         111213902 ns/op          94.29 MB/s
    BenchmarkRead32k              50          69827661 ns/op         150.17 MB/s
    BenchmarkRead128k             50          43963052 ns/op         238.52 MB/s
    BenchmarkRead512k            100          26209817 ns/op         400.07 MB/s
    BenchmarkRead1MiB            100          22649939 ns/op         462.95 MB/s
    BenchmarkRead4MiB             50          35849768 ns/op         292.50 MB/s
    BenchmarkWrite1k               1        2450890588 ns/op           4.28 MB/s
    BenchmarkWrite16k             10         222473163 ns/op          47.13 MB/s
    BenchmarkWrite32k             10         135452515 ns/op          77.41 MB/s
    BenchmarkWrite128k            50          52768404 ns/op         198.72 MB/s
    BenchmarkWrite512k            50          31508170 ns/op         332.80 MB/s
    BenchmarkWrite1MiB            50          27730215 ns/op         378.14 MB/s
    BenchmarkWrite4MiB            50          43410403 ns/op         241.55 MB/s
    BenchmarkMarshalInit     5000000               659 ns/op
    BenchmarkMarshalOpen     5000000               560 ns/op
    BenchmarkMarshalWriteWorstCase     50000             43900 ns/op
    BenchmarkMarshalWrite1k  1000000              2471 ns/op
    ok      github.com/pkg/sftp     44.857s

I also tested a real-world scenario, uploading 500MiB of random data to
a (rather slow embedded) server in my living room:

sftp:

    $ sftp server
    Connected to server.
    sftp> put testdata
    testdata                      100% 500MB  41.7MB/s   00:12

before this commit, with simple client `put.go` and pv (pipe view),
backend is the system ssh client connecting to the sames server as
above, the file is written to the exact same location on the server:

    $ pv testdata | go run put.go
    500MiB 0:00:57 [8.68MiB/s] [=======================>] 100%

With the new code:

    $ pv testdata | go run put.go
    500MiB 0:00:14 [34.9MiB/s] [=======================>] 100%

Then I added 20ms of artificial latency to this server via tc:

    # tc qdisc add dev enp0s25 root netem delay 20ms

Afterwards the difference is even more drastic. First test with sftp
results in 41.7MiB/s. Next with `put.go`, old code is 1.35MiB/s, new
code reaches 30.9MiB/s.